### PR TITLE
Mention creating a starter config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ Searching products:
 
 
 ## How to run the app
+   
+Create a starter config file:
 
-Two possibilities to run it from the command line:
+    touch ~/.myproject.lisp
+
+There are two possibilities to run the app from the command line:
 
     rlwrap sbcl --load run.lisp
 
@@ -41,7 +45,6 @@ Or build the binary and run it:
 Set the port:
 
     PORT=9999 rlwrap sbcl --load run.lisp
-
 
 ## Develop
 


### PR DESCRIPTION
Hi,

The app fails to run if the config file does not exist.

This PR adds an empty starter config that the app expects to be in place before trying to run the app.